### PR TITLE
Remove redundant paragonie/sodium_compat dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,6 @@
     "magento/module-checkout": "100.3.* || 100.4.*",
     "magento/module-payment": "100.3.* || 100.4.*",
     "magento/module-sales": "^102.0.3 || 103.0.*",
-    "paragonie/sodium_compat": "^1.17 || ^2.0.0",
     "php": ">=8.1",
     "ramsey/uuid": "^3.8 || ^4.0",
     "trevipay/trevipay-php": "^1.0.10"


### PR DESCRIPTION
This package depends on `paragonie/sodium_compat: ^1.17 || ^2.0.0`, but also `php: >=8.1`. Since `libsodium` was added in PHP 7.2, the dependency on `paragonie/sodium_compat` seems redundant?